### PR TITLE
auto-fixed-annouces-typo

### DIFF
--- a/HTML/H25_example1.html
+++ b/HTML/H25_example1.html
@@ -44,7 +44,7 @@
                 </li>
                 <li>iOS 10.2.1, Safari browser is based on the iOS version, VoiceOver on iPad 
                      <ul>
-                        <li>Result: iOS VoiceOver annouces this example is demonstrated by using the title h25 example 1 in the head tag end main.</li>
+                        <li>Result: iOS VoiceOver announces this example is demonstrated by using the title h25 example 1 in the head tag end main.</li>
                      </ul>
                 </li>                   
             </ul>

--- a/HTML/H2_example1.html
+++ b/HTML/H2_example1.html
@@ -42,7 +42,7 @@
                 </li>
                 <li>iOS 10.2.1, Safari browser is based on the iOS version, VoiceOver on iPad
                     <ul>
-                        <li>Result: iOS VoiceOver annouces product page link, end main.</li>
+                        <li>Result: iOS VoiceOver announces product page link, end main.</li>
                     </ul>
                 </li>
             </ul>

--- a/HTML/H2_example2.html
+++ b/HTML/H2_example2.html
@@ -46,7 +46,7 @@
                 </li>
                 <li>iOS 10.2.1, Safari browser is based on the iOS version, VoiceOver on iPad
                     <ul>
-                        <li>Result: iOS VoiceOver annouces homepage icon go to home page link, end main.</li>
+                        <li>Result: iOS VoiceOver announces homepage icon go to home page link, end main.</li>
                     </ul>
                 </li>
             </ul>

--- a/HTML/H30_example1.html
+++ b/HTML/H30_example1.html
@@ -36,12 +36,12 @@
             <ul>
                 <li>Windows 7, Firefox ESR 45.4.0, and JAWS 17
                     <ul>
-                        <li>Result: Screen reader annouces link text.</li>
+                        <li>Result: Screen reader announces link text.</li>
                     </ul>
                 </li>
                 <li>iOS 10.2.1, Safari browser is based on the iOS version, VoiceOver on iPad
                     <ul>
-                        <li>Result: iOS VoiceOver annouces current routes at boulders climbing gym link, end main. </li>
+                        <li>Result: iOS VoiceOver announces current routes at boulders climbing gym link, end main. </li>
                     </ul>
                 </li>
             </ul>

--- a/HTML/H30_example2.html
+++ b/HTML/H30_example2.html
@@ -38,12 +38,12 @@
             <ul>
                 <li>Windows 7, Firefox ESR 45.4.0, and JAWS 17
                     <ul>
-                        <li>Result: Screen reader annouces alt text.</li>
+                        <li>Result: Screen reader announces alt text.</li>
                     </ul>
                 </li>
                 <li>iOS 10.2.1, Safari browser is based on the iOS version, VoiceOver on iPad
                     <ul>
-                        <li>Result: iOS VoiceOver annouces current routes at boulders climbing gym link image, end main.</li>
+                        <li>Result: iOS VoiceOver announces current routes at boulders climbing gym link image, end main.</li>
                     </ul>
                 </li>
             </ul>

--- a/HTML/H30_example3.html
+++ b/HTML/H30_example3.html
@@ -39,12 +39,12 @@
             <ul>
                 <li>Windows 7, Firefox ESR 45.4.0, and JAWS 17
                     <ul>
-                        <li>Result: Screen reader annouces link text.</li>
+                        <li>Result: Screen reader announces link text.</li>
                     </ul>
                 </li>
                 <li>iOS 10.2.1, Safari browser is based on the iOS version, VoiceOver on iPad
                     <ul>
-                        <li>Result: iOS VoiceOver annouces current routes at boulders climbing gym link, end main. </li>
+                        <li>Result: iOS VoiceOver announces current routes at boulders climbing gym link, end main. </li>
                     </ul>
                 </li>
             </ul>

--- a/HTML/H30_example4.html
+++ b/HTML/H30_example4.html
@@ -38,12 +38,12 @@
             <ul>
                 <li>Windows 7, Firefox ESR 45.4.0, and JAWS 17
                     <ul>
-                        <li>Result: Screen reader annouces link text and alt text.</li>
+                        <li>Result: Screen reader announces link text and alt text.</li>
                     </ul>
                 </li>
                 <li>iOS 10.2.1, Safari browser is based on the iOS version, VoiceOver on iPad
                     <ul>
-                        <li>Result: iOS VoiceOver annouces feeback response received icon link, end main. </li>
+                        <li>Result: iOS VoiceOver announces feeback response received icon link, end main. </li>
                     </ul>
                 </li>
             </ul>

--- a/HTML/H30_example5.html
+++ b/HTML/H30_example5.html
@@ -39,7 +39,7 @@
             <ul>
                 <li>Windows 7, Firefox ESR 45.4.0, and JAWS 17
                     <ul>
-                        <li>Result: Screen reader annouces link text and PDF format.</li>
+                        <li>Result: Screen reader announces link text and PDF format.</li>
                     </ul>
                 </li>
                 <li>iOS 10.2.1, Safari browser is based on the iOS version, VoiceOver on iPad

--- a/HTML/H30_example6.html
+++ b/HTML/H30_example6.html
@@ -40,12 +40,12 @@
             <ul>
                 <li>Windows 7, Firefox ESR 45.4.0, and JAWS 17
                     <ul>
-                        <li>Result: Screen reader annouces link text.</li>
+                        <li>Result: Screen reader announces link text.</li>
                     </ul>
                 </li>
                 <li>iOS 10.2.1, Safari browser is based on the iOS version, VoiceOver on iPad
                     <ul>
-                        <li>Result: iOS VoiceOver annouces </li>
+                        <li>Result: iOS VoiceOver announces </li>
                         <ul>
                             <li>MyCorp 2009 annual report pfd link.</li>
                             <li>MyCopr 2009 annula bugget exel link, end main.</li>

--- a/HTML/H30_example7.html
+++ b/HTML/H30_example7.html
@@ -42,12 +42,12 @@
             <ul>
                 <li>Windows 7, Firefox ESR 45.4.0, and JAWS 17
                     <ul>
-                        <li>Result: Screen reader annouces link text.</li>
+                        <li>Result: Screen reader announces link text.</li>
                     </ul>
                 </li>
                 <li>iOS 10.2.1, Safari browser is based on the iOS version, VoiceOver on iPad
                     <ul>
-                        <li>Result: iOS VoiceOver annouces </li>
+                        <li>Result: iOS VoiceOver announces </li>
                             <ul>
                                 <li>Budget debate continues in parliament heading level 3 link, budget debate article landmark.</li>
                                 <li>Break news link image.</li>

--- a/HTML/H34_example1.html
+++ b/HTML/H34_example1.html
@@ -42,7 +42,7 @@
                 </li>
                 <li>iOS 10.2.1, Safari browser is based on the iOS version, VoiceOver on iPad
                     <ul>
-                        <li>Result: iOS VoiceOver annouces</li>
+                        <li>Result: iOS VoiceOver announces</li>
                         <li>The tile is (English voice).</li>
                         <li>فتاح معايير الويب!(Arabic voice).</li>
                         <li>In Arabic, end main.</li>

--- a/HTML/H36_example1.html
+++ b/HTML/H36_example1.html
@@ -42,7 +42,7 @@
                 </li>
                 <li>iOS 10.2.1, Safari browser is based on the iOS version, VoiceOver on iPad
                     <ul>
-                        <li>Result: iOS VoiceOver annouces submit button, end main.</li>
+                        <li>Result: iOS VoiceOver announces submit button, end main.</li>
                         </ul>
                 </li>
             </ul>

--- a/HTML/H43_example1.html
+++ b/HTML/H43_example1.html
@@ -64,7 +64,7 @@
                 </li>
                 <li>iOS 10.2.1, Safari browser is based on the iOS version, VoiceOver on iPad 
                     <ul>
-                        <li>Result: iOS VoiceOver annouces </li>
+                        <li>Result: iOS VoiceOver announces </li>
                         <ul>
                             <li>A data table displaying the percentage of the homework exames and 
                                 projects that make up the students total grade.</li>

--- a/HTML/H4_example1.html
+++ b/HTML/H4_example1.html
@@ -80,7 +80,7 @@
                 </li>
                 <li>iOS 10.2.1, Safari browser is based on the iOS version, VoiceOver on iPad
                     <ul>
-                        <li> Result: iOS VoiceOver annouces </li>
+                        <li> Result: iOS VoiceOver announces </li>
                           <ul>
                               <li>First name of groom row2 colum2 text field, it's editting, character mode, insertion point start.</li>
                               <li>Last name of groom row3 colum2 text field,it's editting, character mode, inserstion point start.</li>

--- a/HTML/H4_example2.html
+++ b/HTML/H4_example2.html
@@ -49,7 +49,7 @@
                 </li>
                 <li>iOS 10.2.1, Safari browser is based on the iOS version, VoiceOver on iPad
                     <ul>
-                        <li> Result: iOS VoiceOver annouces <li>
+                        <li> Result: iOS VoiceOver announces <li>
                             <ul>
                                 <li>First link in the list link.</li> 
                                 <li>Second link in list link.</li>

--- a/HTML/H84_example2.html
+++ b/HTML/H84_example2.html
@@ -43,7 +43,7 @@
             <ul>
                 <li>Windows 7, Firefox ESR 45.4.0, and JAWS 17
                     <ul>
-                        <li>Result: Screen reader annouces combo box and value. Context does not change until the Do It button is selected.</li>
+                        <li>Result: Screen reader announces combo box and value. Context does not change until the Do It button is selected.</li>
                     </ul>
                 </li>
             </ul>

--- a/HTML/H94_example1.html
+++ b/HTML/H94_example1.html
@@ -42,7 +42,7 @@
                 <li>iOS 10.2.1, Safari browser is based on the iOS version, VoiceOver on iPad
                     <ul>
                         <li>Result: Manually inspected the code there is unique id="state". 
-                            iOS VoiceOver annouces city Austin, state Texas.</li>
+                            iOS VoiceOver announces city Austin, state Texas.</li>
                     </ul>
                 </li>
             </ul>

--- a/HTML/H96_example1.html
+++ b/HTML/H96_example1.html
@@ -44,7 +44,7 @@
                 </li>
                 <li>iOS 10.2.1, Safari browser is based on the iOS version, VoiceOver on iPad 
                     <ul>
-                        <li>Result: iOS VoiceOver annouces audio description on the video.</li>       
+                        <li>Result: iOS VoiceOver announces audio description on the video.</li>       
                     </ul>
                 </li>
             </ul>

--- a/HTML/H96_example2.html
+++ b/HTML/H96_example2.html
@@ -46,7 +46,7 @@
                 </li>
                 <li>iOS 10.2.1, Safari browser is based on the iOS version, VoiceOver on iPad 
                     <ul>
-                        <li>Result: iOS VoiceOver annouces audio descriptions on the video.</li>
+                        <li>Result: iOS VoiceOver announces audio descriptions on the video.</li>
                     </ul>
                 </li>
             </ul>


### PR DESCRIPTION
Used perl -pi -w -e 's/annouces/announces/g;' *.html to auto fix “annouces” typo in several files.