### PR TITLE
fixed “annouces” typo with “announces”

### DIFF
--- a/HTML/H24_example1.html
+++ b/HTML/H24_example1.html
@@ -47,7 +47,7 @@
                 </li>
                 <li>iOS 10.2.1, Safari browser is based on the iOS version , VoiceOver on iPad
                     <ul>
-                        <li>Result: iOS VoiceOver annouces areas in the library, select an area for more information 
+                        <li>Result: iOS VoiceOver announces areas in the library, select an area for more information 
                             on that area, end main. "single touch the screen and move around to find out map regoion" 
                             References link action available. Audio lab link action available.
                         </li>

--- a/HTML/H32_example1.html
+++ b/HTML/H32_example1.html
@@ -45,7 +45,7 @@
                 </li>
                 <li>iOS 10.2.1, Safari browser is based on the iOS version, VoiceOver on iPad
                     <ul>
-                        <li>Result: iOS VoiceOver annouces. </li>
+                        <li>Result: iOS VoiceOver announces. </li>
                         <ul>
                             <li>Enter email address text field.</li>
                             <li>Subsribe botton, end main.</li>

--- a/HTML/H32_example2.html
+++ b/HTML/H32_example2.html
@@ -49,7 +49,7 @@
                 </li>
                 <li>iOS 10.2.1, Safari browser is based on the iOS version, VoiceOver on iPad
                     <ul>
-                        <li>Result: iOS VoiceOver annouces</li>
+                        <li>Result: iOS VoiceOver announces</li>
                         <ul>
                             <li>Navigate the site home pop-up button. double-tab the activate the picker, "Home" is selected on the combo box. 
                                 To change the selection use the figure flick up or down on the screen. redirects to the user to the requested page (Example Domain page)</li>

--- a/HTML/H33_example1.html
+++ b/HTML/H33_example1.html
@@ -42,7 +42,7 @@
                 </li>
                 <li>iOS 10.2.1, Safari browser is based on the iOS version, VoiceOver on iPad
                     <ul>
-                        <li>Result: iOS VoiceOver annouces evaculation crumbles under jumbo load. 
+                        <li>Result: iOS VoiceOver announces evaculation crumbles under jumbo load. 
                             link, end main. Read more about failed elephant evacuation.</li>
                     </ul>
                 </li>

--- a/HTML/H37_example1.html
+++ b/HTML/H37_example1.html
@@ -40,7 +40,7 @@
                 </li>
                 <li>iOS 10.2.1, Safari browser is based on the iOS version, VoiceOver on iPad
                     <ul>
-                        <li>Result: iOS VoiceOver annouces free newsletter get free recipes news and more learn more image,
+                        <li>Result: iOS VoiceOver announces free newsletter get free recipes news and more learn more image,
                             end main.
                         </li>
                     </ul>

--- a/HTML/H39_example1.html
+++ b/HTML/H39_example1.html
@@ -122,7 +122,7 @@
                 </li>
                 <li>iOS 10.2.1, Safari browser is based on the iOS version, VoiceOver on iPad
                     <ul> 
-                        <li>Result: iOS VoiceOver annouces</li>
+                        <li>Result: iOS VoiceOver announces</li>
                            <ul>
                                <li>Schedule for the week of 06 March 2016, table start, 10 rows, 6 columns.</li>
                                <li>March 6 row1 column2, March 7 colum3, March 8 colum4, March 9 column5, March 10 column6.</li>

--- a/HTML/H42_example1.html
+++ b/HTML/H42_example1.html
@@ -58,7 +58,7 @@
                 </li>
                 <li>iOS 10.2.1, Safari browser is based on the iOS version, VoiceOver on iPad
                     <ul>
-                        <li>Result: iOS VoiceOver annouces</li>
+                        <li>Result: iOS VoiceOver announces</li>
                             <ul>
                                 <li>Plant food the human eat, heading level 1.</li>
                                 <li>Fruit heading level 2.</li>

--- a/HTML/H44_example1.html
+++ b/HTML/H44_example1.html
@@ -56,7 +56,7 @@
                 </li>
                 <li>iOS 10.2.1, Safari browser is based on the iOS version, VoiceOver on iPad
                     <ul>
-                        <li>Result: iOS VoiceOver annouces first name text field, end main.</li>
+                        <li>Result: iOS VoiceOver announces first name text field, end main.</li>
                     </ul>
                 </li>
             </ul>

--- a/HTML/H44_example2.html
+++ b/HTML/H44_example2.html
@@ -41,7 +41,7 @@
                 </li>
                 <li>iOS 10.2.1, Safari browser is based on the iOS version, VoiceOver on iPad
                     <ul>
-                        <li>Result: iOS VoiceOver annouces HTML check box checked. </li>
+                        <li>Result: iOS VoiceOver announces HTML check box checked. </li>
                     </ul>
                 </li>
             </ul>

--- a/HTML/H44_example3.html
+++ b/HTML/H44_example3.html
@@ -56,7 +56,7 @@
                 </li>
                 <li>iOS 10.2.1, Safari browser is based on the iOS version, VoiceOver on iPad
                     <ul>
-                        <li>Result: iOS VoiceOver annouces </li>
+                        <li>Result: iOS VoiceOver announces </li>
                            <ul>
                               <li> Chocolate radio button unchecked 1 of 3.</li>
                               <li> Cream filled radio button unchecked 2 of 3</li>

--- a/HTML/H48_example1.html
+++ b/HTML/H48_example1.html
@@ -43,7 +43,7 @@
                 </li>
                 <li>iOS 10.2.1, Safari browser is based on the iOS version, VoiceOver on iPad 
                     <ul>
-                        <li>Result: iOS VoiceOver annouces </li>
+                        <li>Result: iOS VoiceOver announces </li>
                         <ul>
                             <li>1 list start, mix eggs and milk in a bowl.</li>
                             <li>2 add salt and peper list end, end, end main.</li>

--- a/HTML/H48_example2.html
+++ b/HTML/H48_example2.html
@@ -44,7 +44,7 @@
                 </li>
                 <li>iOS 10.2.1, Safari browser is based on the iOS version, VoiceOver on iPad 
                     <ul>
-                        <li>Result: iOS VoiceOver annouces </li>
+                        <li>Result: iOS VoiceOver announces </li>
                         <ul>
                             <li>Bullet list start Milk.</li>
                             <li>Bullet eggs.</li>

--- a/HTML/H48_example3.html
+++ b/HTML/H48_example3.html
@@ -43,7 +43,7 @@
                 </li>
                 <li>iOS 10.2.1, Safari browser is based on the iOS version, VoiceOver on iPad 
                     <ul>
-                        <li>Result: iOS VoiceOver annouces </li>
+                        <li>Result: iOS VoiceOver announces </li>
                         <ul>
                             <li>blink.</li>
                             <li>Turn on and off between 5 and 3 times per second end main.</li>

--- a/HTML/H48_example4.html
+++ b/HTML/H48_example4.html
@@ -45,7 +45,7 @@
                 </li>
                 <li>iOS 10.2.1, Safari browser is based on the iOS version, VoiceOver on iPad 
                     <ul>
-                        <li>Result: iOS VoiceOver annouces </li>
+                        <li>Result: iOS VoiceOver announces </li>
                         <ul>
                             <li>Name.Jone Doe.</li>
                             <li>Tel 012345678 link.</li>

--- a/HTML/H49_example2.html
+++ b/HTML/H49_example2.html
@@ -46,7 +46,7 @@
                 </li>
                 <li>iOS 10.2.1, Safari browser is based on the iOS version, VoiceOver on iPad 
                     <ul>
-                        <li>Result: iOS VoiceOver annouces </li>
+                        <li>Result: iOS VoiceOver announces </li>
                         <ul>
                             <li>The following is an except from the. The story of my life by Hellen Keller.</li>
                             <li>Even the days before my teacher came I used  to feel along the square stiff boxwood hedges 

--- a/HTML/H49_example3.html
+++ b/HTML/H49_example3.html
@@ -42,7 +42,7 @@
                 </li>
                 <li>iOS 10.2.1, Safari browser is based on the iOS version, VoiceOver on iPad 
                     <ul>
-                        <li>Result: iOS VoiceOver annouces Helen Keeer said. Self pity is our worst enemy and if we yeild to it we can never do anything good 
+                        <li>Result: iOS VoiceOver announces Helen Keeer said. Self pity is our worst enemy and if we yeild to it we can never do anything good 
                                     in the world.
                                     Note: iOS VoiceOver did not announce quotation marks in sentence.</li>
                     </ul>

--- a/HTML/H49_example4.html
+++ b/HTML/H49_example4.html
@@ -41,7 +41,7 @@
                 </li>
                 <li>iOS 10.2.1, Safari browser is based on the iOS version, VoiceOver on iPad 
                     <ul>
-                        <li>Result: iOS VoiceOver annouces </li>
+                        <li>Result: iOS VoiceOver announces </li>
                         <ul>
                             <li>Beth receive 1 Street, place in the 9 Th. grade science completation.</li>
                             <li>The chemical notation for water is H2O.</li>

--- a/HTML/H51_example1.html
+++ b/HTML/H51_example1.html
@@ -66,7 +66,7 @@
                 <li>iOS 10.2.1, Safari browser is based on the iOS version, VoiceOver on iPad 
                     <ul>
                         <li>Result: iOS VoiceOver did not read content as expected.  
-                            Column headings read out of order. VoiceOver annouces: </li>
+                            Column headings read out of order. VoiceOver announces: </li>
                         <ul>
                             <li>Tuesday Monday row1 colum2 table start 3 rows, 6 colums.</li>
                             <li>Wednesday Tuesday colum3.</li>
@@ -82,7 +82,7 @@
                          </ul>
                      </ul>
                      <ul>
-                        <li>Result: iOS VoiceOver annouces</li>
+                        <li>Result: iOS VoiceOver announces</li>
                         <ul>
                             <li>Monday row1 colum2, table start 3 rows, 6 colums.</li>
                             <li>Tuesday row1 colum3.</li>

--- a/HTML/H56_example1.html
+++ b/HTML/H56_example1.html
@@ -41,7 +41,7 @@
                 </li>
                 <li>iOS 10.2.1, Safari browser is based on the iOS version, VoiceOver on iPad 
                     <ul>
-                        <li>Result: iOS VoiceOver annouces the title says פעילות הבינאום in Hebrew. </li>      
+                        <li>Result: iOS VoiceOver announces the title says פעילות הבינאום in Hebrew. </li>      
                     </ul>
                 </li>
             </ul>

--- a/HTML/H58_example1.html
+++ b/HTML/H58_example1.html
@@ -56,7 +56,7 @@
                 </li>
                 <li>iOS 10.2.1, Safari browser is based on the iOS version, VoiceOver on iPad 
                     <ul>
-                        <li>Result: iOS VoiceOver annouces paragraph content in German voice: Da dachte der Herr daran, ihn aus dem Futter zu schaffen, aber der Esel merkte, daß kein guter Wind wehte, lief fort und machte sich auf den Weg nach Bremen: dort, meinte er, könnte er ja Stadtmusikant werden.
+                        <li>Result: iOS VoiceOver announces paragraph content in German voice: Da dachte der Herr daran, ihn aus dem Futter zu schaffen, aber der Esel merkte, daß kein guter Wind wehte, lief fort und machte sich auf den Weg nach Bremen: dort, meinte er, könnte er ja Stadtmusikant werden.
                  </li>
                     </ul>             
                 </li>

--- a/HTML/H59_example1.html
+++ b/HTML/H59_example1.html
@@ -49,7 +49,7 @@
                 </li>
                 <li>iOS 10.2.1, Safari browser is based on the iOS version, VoiceOver on iPad
                     <ul>
-                        <li>Result: iOS VoiceOver annouces 3 links.</li>
+                        <li>Result: iOS VoiceOver announces 3 links.</li>
                         <ul>
                            <li>Home link, navigation landmark.</li>
                            <li>Greater than.</li>

--- a/HTML/H63_example1.html
+++ b/HTML/H63_example1.html
@@ -100,7 +100,7 @@
                 <li>iOS 10.2.1, Safari browser is based on the iOS version, VoiceOver on iPad
                     <ul>
                         <li>Result: "iOS VoiceOver did not read content as expected as appy the roter feature 
-                            Column headings read out of order.  VoiceOver annouces:"</li>
+                            Column headings read out of order.  VoiceOver announces:"</li>
                         <ul>
                             <li>Contact information.</li>
                             <li>Phone number sign, name column2.</li>
@@ -124,7 +124,7 @@
                             <li>Houston, colunn5 table end, end, contact information, end main.</li>
                         </ul>
                         
-                        <li>Result: iOS VoiceOver annouces </li>
+                        <li>Result: iOS VoiceOver announces </li>
                         <ul>
                             <li>Contact information, table start 4 rows 5 columns.</li>
                             <li>Name row1 column2.</li>

--- a/HTML/H64_example1.html
+++ b/HTML/H64_example1.html
@@ -40,7 +40,7 @@
                 </li>
                 <li>iOS 10.2.1, Safari browser is based on the iOS version, VoiceOver on iPad
                     <ul>
-                        <li>Result: Activate Simple frameset document link, the  iOS VoiceOver annouces 
+                        <li>Result: Activate Simple frameset document link, the  iOS VoiceOver announces 
                            <ul>
                                <li>1 list start 1.</li>
                                <li>Document link, action availble.</li>

--- a/HTML/H64_example2.html
+++ b/HTML/H64_example2.html
@@ -40,7 +40,7 @@
                 </li>
                 <li>iOS 10.2.1, Safari browser is based on the iOS version, VoiceOver on iPad
                     <ul>
-                        <li>Result: After the actvate the a document using iframe link. iOS VoiceOver annouces IBM banner image, banner landmark. </li>
+                        <li>Result: After the actvate the a document using iframe link. iOS VoiceOver announces IBM banner image, banner landmark. </li>
                             
                      </ul>
                 </li>

--- a/HTML/H65_example1.html
+++ b/HTML/H65_example1.html
@@ -47,7 +47,7 @@
                 </li>
                 <li>iOS 10.2.1, Safari browser is based on the iOS version, VoiceOver on iPad
                     <ul>
-                        <li>Result: iOS VoiceOver annouces </li>
+                        <li>Result: iOS VoiceOver announces </li>
                             <ul>
                                 <li>Search for text field.</li>
                                 <li>Search in books popup button, end main.</li>

--- a/HTML/H65_example2.html
+++ b/HTML/H65_example2.html
@@ -47,7 +47,7 @@
                 </li>
                 <li>iOS 10.2.1, Safari browser is based on the iOS version, VoiceOver on iPad
                     <ul>
-                        <li>Result: iOS VoiceOver annouces
+                        <li>Result: iOS VoiceOver announces
                            <ul>
                                <li>Area code text field.</li>
                                <li>First 3 digits of phone number text field.</li>

--- a/HTML/H65_example3.html
+++ b/HTML/H65_example3.html
@@ -40,7 +40,7 @@
                 </li>
                 <li>iOS 10.2.1, Safari browser is based on the iOS version, VoiceOver on iPad
                     <ul>
-                        <li>Result: iOS VoiceOver annouces </li>
+                        <li>Result: iOS VoiceOver announces </li>
                             <ul>
                                 <li>Type search term here text field.</li>
                                 <li>Search button end main.</li>

--- a/HTML/H69_example1.html
+++ b/HTML/H69_example1.html
@@ -54,7 +54,7 @@
                 </li>
                 <li>iOS 10.2.1, Safari browser is based on the iOS version, VoiceOver on iPad
                     <ul>
-                        <li>Result: iOS VoiceOver annouces </li>
+                        <li>Result: iOS VoiceOver announces </li>
                             <ul> 
                                 <li>Search Technical Periodicals heading level 1.</li>
                                 <li>Search heading level 2.</li>

--- a/HTML/H69_example2.html
+++ b/HTML/H69_example2.html
@@ -49,7 +49,7 @@
                 </li>
                 <li>iOS 10.2.1, Safari browser is based on the iOS version, VoiceOver on iPad
                     <ul>
-                        <li>Result: iOS VoiceOver annouces  </li>
+                        <li>Result: iOS VoiceOver announces  </li>
                         <ul>
                             <li>Navigation heading level 2.</li>
                             <li>All about headings heading level 2, end main.</li>

--- a/HTML/H69_example3.html
+++ b/HTML/H69_example3.html
@@ -40,7 +40,7 @@
                 </li>
                 <li>iOS 10.2.1, Safari browser is based on the iOS version, VoiceOver on iPad
                     <ul>
-                        <li>Result: iOS VoiceOver annouces</li>
+                        <li>Result: iOS VoiceOver announces</li>
                             <ul>
                                 <li>Cooking techniques heading 1 main landmark.</li>
                                 <li>Cooking with oil heading level 2.</li>

--- a/HTML/H70_example1.html
+++ b/HTML/H70_example1.html
@@ -40,7 +40,7 @@
                 </li>
                 <li>iOS 10.2.1, Safari browser is based on the iOS version, VoiceOver on iPad
                     <ul>
-                        <li>Result: iOS VoiceOver annouces navigation bar heading level 1, main landmark
+                        <li>Result: iOS VoiceOver announces navigation bar heading level 1, main landmark
                             <ul>
                                 <li>Navigation bar heading level 1 main landmark.</li>
                                 <li>Main news contents heading level 1 main landmark.</li>

--- a/HTML/H71_example1.html
+++ b/HTML/H71_example1.html
@@ -52,7 +52,7 @@
                 </li>
                 <li>iOS 10.2.1, Safari browser is based on the iOS version, VoiceOver on iPad 
                     <ul>
-                        <li>Result: iOS VoiceOver annouces
+                        <li>Result: iOS VoiceOver announces
                             <ul>
                                <li>Hamlet Was written by, main.</li>
                                <li>William Shakespeare radio button checked 1 of 5.</li>

--- a/HTML/H71_example2.html
+++ b/HTML/H71_example2.html
@@ -49,7 +49,7 @@
                 </li>
                 <li>iOS 10.2.1, Safari browser is based on the iOS version, VoiceOver on iPad 
                     <ul>
-                        <li>Result: iOS VoiceOver annouces </li>
+                        <li>Result: iOS VoiceOver announces </li>
                         <ul>
                             <li>I am interested in the following check all that apply. main.</li>
                             <li>Photography checkbox unchecked.</li>

--- a/HTML/H71_example3.html
+++ b/HTML/H71_example3.html
@@ -51,7 +51,7 @@
                 </li>
                 <li>iOS 10.2.1, Safari browser is based on the iOS version, VoiceOver on iPad 
                     <ul>
-                        <li>Result: iOS VoiceOver annouces </li>
+                        <li>Result: iOS VoiceOver announces </li>
                         <ul>
                             <li>Your preferred philosopher main.</li>
                             <li>Scocrates radio button unchecked 1 of 3.</li>

--- a/HTML/H71_example4.html
+++ b/HTML/H71_example4.html
@@ -59,7 +59,7 @@
                 </li>
                 <li>iOS 10.2.1, Safari browser is based on the iOS version, VoiceOver on iPad 
                     <ul>
-                        <li>Result: iOS VoiceOver annouces </li>
+                        <li>Result: iOS VoiceOver announces </li>
                         <ul>
                             <li>Residential address main.</li>
                             <li>Address text field.</li>

--- a/HTML/H73_example1.html
+++ b/HTML/H73_example1.html
@@ -55,7 +55,7 @@
                 </li>
                 <li>iOS 10.2.1, Safari browser is based on the iOS version, VoiceOver on iPad 
                     <ul>
-                        <li>Result: iOS VoiceOver did not read summary table as expected. VoiceOver annouces </li>
+                        <li>Result: iOS VoiceOver did not read summary table as expected. VoiceOver announces </li>
                         <ul>
                             <li>State and first rows1 column1 table start 2 rows 4 columns.</li>
                             <li>State and sixth column2.</li>

--- a/HTML/H73_example2.html
+++ b/HTML/H73_example2.html
@@ -58,7 +58,7 @@
                 </li>
                 <li>iOS 10.2.1, Safari browser is based on the iOS version, VoiceOver on iPad 
                     <ul>
-                        <li>Result: iOS VoiceOver did not read summary table as expected. iOS VoiceOver annouces </li>
+                        <li>Result: iOS VoiceOver did not read summary table as expected. iOS VoiceOver announces </li>
                         <ul>
                             <li>Route 7 downtown weekdays table start 2 rows 4 columns.</li>
                             <li>State and first row1 column1.</li>

--- a/HTML/H77_example2.html
+++ b/HTML/H77_example2.html
@@ -61,7 +61,7 @@
                 </li>
                 <li>iOS 10.2.1, Safari browser is based on the iOS version, VoiceOver on iPad 
                     <ul>
-                        <li>Result: iOS VoiceOver annouces </li>
+                        <li>Result: iOS VoiceOver announces </li>
                         <ul>
                             <li>Bullte list start, Tomb raifer legend link, see images link. download demon link.</li>
                             <li>Bullet F E A R Extraction point link.see images link, download demon link.

--- a/HTML/H78_example1.html
+++ b/HTML/H78_example1.html
@@ -51,7 +51,7 @@
                 </li>
                 <li>iOS 10.2.1, Safari browser is based on the iOS version, VoiceOver on iPad
                     <ul>
-                        <li>Result: iOS VoiceOver annouces </li>
+                        <li>Result: iOS VoiceOver announces </li>
                         <ul>
                             <li>The final 15</li>
                             <li>Comming soon to the town near you ellipsis the final 15 in the National Folk Festval lineup.

--- a/HTML/H79_example1.html
+++ b/HTML/H79_example1.html
@@ -82,7 +82,7 @@
                 <li>iOS 10.2.1, Safari browser is based on the iOS version, VoiceOver on iPad
                     <li>iOS 10.2.1, Safari browser is based on the iOS version, VoiceOver on iPad 
                     <ul>
-                        <li>Result: iOS VoiceOver annouces </li>
+                        <li>Result: iOS VoiceOver announces </li>
                         <ul>
                             <li>Alamo row1 column2, table start, 5 rows 6 columns.</li>
                             <li>Budget column3.</li>

--- a/HTML/H80_example1.html
+++ b/HTML/H80_example1.html
@@ -56,7 +56,7 @@
                 </li>
                 <li>iOS 10.2.1, Safari browser is based on the iOS version, VoiceOver on iPad 
                     <ul>
-                        <li>Result: iOS VoiceOver annouces </li>
+                        <li>Result: iOS VoiceOver announces </li>
                         <ul>
                             <li>Royal Palm hotel link, heading level 2 link.</li>
                             <li>Bullet, list start, Map link.</li>

--- a/HTML/H80_example2.html
+++ b/HTML/H80_example2.html
@@ -45,7 +45,7 @@
                 </li>
                 <li>iOS 10.2.1, Safari browser is based on the iOS version, VoiceOver on iPad 
                     <ul>
-                        <li>Result: iOS VoiceOver annouces </li>
+                        <li>Result: iOS VoiceOver announces </li>
                         <ul>
                             <li>HTMl link.</li>
                             <li>PDF link.</li>

--- a/HTML/H80_example3.html
+++ b/HTML/H80_example3.html
@@ -42,7 +42,7 @@
                 </li>
                 <li>iOS 10.2.1, Safari browser is based on the iOS version, VoiceOver on iPad 
                     <ul>
-                        <li>Result: iOS VoiceOver annouces </li>
+                        <li>Result: iOS VoiceOver announces </li>
                         <ul>
                             <li>Stock market soars as bullishness prevails, heading level 2, link.</li>
                             <li>More here link, end, main.</li>

--- a/HTML/H81_example1.html
+++ b/HTML/H81_example1.html
@@ -56,7 +56,7 @@
                 </li>
                 <li>iOS 10.2.1, Safari browser is based on the iOS version, VoiceOver on iPad 
                     <ul>
-                        <li>Result: iOS VoiceOver annouces </li>
+                        <li>Result: iOS VoiceOver announces </li>
                         <ul>
                             <li>Annual Report 2 0 0 5 2 0 0 6.</li>
                             <li>White bullet, list start, HTML link.</li>

--- a/HTML/H83_example1.html
+++ b/HTML/H83_example1.html
@@ -40,7 +40,7 @@
                 </li>
                 <li>iOS 10.2.1, Safari browser is based on the iOS version, VoiceOver on iPad
                     <ul>
-                        <li>Result: iOS VoiceOver annouces
+                        <li>Result: iOS VoiceOver announces
                             show help open the new window, link, end, main. 
                             "double click on the screen a new page open" VoiceOver announces: Wed page loaded.
                             This is placeholder page slash dummy file with no real content. The purpose of this page is simple 

--- a/HTML/H84_example1.html
+++ b/HTML/H84_example1.html
@@ -75,7 +75,7 @@
                 </li>
                 <li>iOS 10.2.1, Safari browser is based on the iOS version, VoiceOver on iPad
                     <ul>
-                        <li>Result: iOS VoiceOver annouces
+                        <li>Result: iOS VoiceOver announces
                             <ul>
                                 <li>Select a Month and enter a Year</li>
                                 <li>Month, Month Januaray, popup button.</li>

--- a/HTML/H84_example2.html
+++ b/HTML/H84_example2.html
@@ -48,7 +48,7 @@
                 </li>
                 <li>iOS 10.2.1, Safari browser is based on the iOS version, VoiceOver on iPad
                     <ul>
-                        <li>Result: iOS VoiceOver annouces
+                        <li>Result: iOS VoiceOver announces
                             <ul>
                                <li>Options, help popup button "help button selected by default on the combo box list, double tap to activate the picker.</li>
                                <li>Do it button, end, main."After Do it button is selected. </li>

--- a/HTML/H85_example1.html
+++ b/HTML/H85_example1.html
@@ -61,7 +61,7 @@
                 </li>
                 <li>iOS 10.2.1, Safari browser is based on the iOS version, VoiceOver on iPad 
                     <ul>
-                        <li>Result: iOS VoiceOver annouces </li>
+                        <li>Result: iOS VoiceOver announces </li>
                         <ul>
                             <li>What's your favoritie food, apples, pop-up button, double tap to activate the picker.</li>
                             <li>Fruits, heading.</li>

--- a/HTML/H85_example2.html
+++ b/HTML/H85_example2.html
@@ -78,7 +78,7 @@
                 </li>
                 <li>iOS 10.2.1, Safari browser is based on the iOS version, VoiceOver on iPad 
                     <ul>
-                        <li>Result: iOS VoiceOver annouces</li>
+                        <li>Result: iOS VoiceOver announces</li>
                         <ul>
                             <li>Related Techniques, 0items, pop-up button, doule tap to active the picker.</li>
                             <li>Gernal techniques heading.</li>

--- a/HTML/H86_example1.html
+++ b/HTML/H86_example1.html
@@ -44,7 +44,7 @@
                 </li>
                 <li>iOS 10.2.1, Safari browser is based on the iOS version, VoiceOver on iPad
                     <ul>
-                        <li>Result: iOS VoiceOver annouces equal 8-0 fight, equal 8.0 fright image, end main.</li>
+                        <li>Result: iOS VoiceOver announces equal 8-0 fight, equal 8.0 fright image, end main.</li>
                     </ul>
                 </li>
             </ul>

--- a/HTML/H86_example2.html
+++ b/HTML/H86_example2.html
@@ -91,7 +91,7 @@
                 </li>
                 <li>iOS 10.2.1, Safari browser is based on the iOS version, VoiceOver on iPad
                     <ul>
-                        <li>Result: iOS VoiceOver annouces figure 1 ASCII art picture of a butterfly, skip ASCII image link. lllllll underscore....lllllllll underscore..... </li>
+                        <li>Result: iOS VoiceOver announces figure 1 ASCII art picture of a butterfly, skip ASCII image link. lllllll underscore....lllllllll underscore..... </li>
                     </ul>
                 </li>
             </ul>

--- a/HTML/H86_example3.html
+++ b/HTML/H86_example3.html
@@ -40,7 +40,7 @@
                 </li>
                 <li>iOS 10.2.1, Safari browser is based on the iOS version, VoiceOver on iPad 
                     <ul>
-                        <li>Result: iOS VoiceOver annouces au5t1nr0xx0rz</li>
+                        <li>Result: iOS VoiceOver announces au5t1nr0xx0rz</li>
                         
                      </ul>
                  </li>

--- a/HTML/H89_example1.html
+++ b/HTML/H89_example1.html
@@ -45,7 +45,7 @@
                 </li>
                 <li>iOS 10.2.1, Safari browser is based on the iOS version, VoiceOver on iPad 
                     <ul>
-                        <li>Result: iOS VoiceOver annouces</li>
+                        <li>Result: iOS VoiceOver announces</li>
                           <ul>
                               <li>Address text field, end, main.</li>
                               <li>101 Collins Street, Melbourne, Australia, double tap to edit.</li>

--- a/HTML/H89_example2.html
+++ b/HTML/H89_example2.html
@@ -45,7 +45,7 @@
                 </li>
                 <li>iOS 10.2.1, Safari browser is based on the iOS version, VoiceOver on iPad 
                     <ul>
-                        <li>Result: iOS VoiceOver annouces </li>
+                        <li>Result: iOS VoiceOver announces </li>
                         <ul>
                             <li>Account number, text field, end, main.</li>
                             <li>Your account number can be found in the top right-hand corner of your bill, double tap to edit.</li>

--- a/HTML/H90_example1.html
+++ b/HTML/H90_example1.html
@@ -44,7 +44,7 @@
                 </li>
                 <li>iOS 10.2.1, Safari browser is based on the iOS version, VoiceOver on iPad 
                     <ul>
-                        <li>Result: iOS VoiceOver annouces first name, required, firs name required text field, end main.</li>
+                        <li>Result: iOS VoiceOver announces first name, required, firs name required text field, end main.</li>
                      </ul>
                 </li>
             </ul>

--- a/HTML/H90_example2.html
+++ b/HTML/H90_example2.html
@@ -46,7 +46,7 @@
                 </li>
                 <li>iOS 10.2.1, Safari browser is based on the iOS version, VoiceOver on iPad 
                     <ul>
-                        <li>Result: iOS VoiceOver annouces</li>
+                        <li>Result: iOS VoiceOver announces</li>
                           <ul>
                              <li>Required fields are marked with an astersisk star.</li>
                              <li>First name, star, first name star text field, end main.</li>

--- a/HTML/H90_example3.html
+++ b/HTML/H90_example3.html
@@ -48,7 +48,7 @@
                 </li>
                 <li>iOS 10.2.1, Safari browser is based on the iOS version, VoiceOver on iPad 
                     <ul>
-                        <li>Result: iOS VoiceOver annouces</li>
+                        <li>Result: iOS VoiceOver announces</li>
                             <ul>
                                 <li>Required Control image indicates that the form control is require.</li>
                                 <li>First name required conttol image, first name required control text field.</li>

--- a/HTML/H90_example4.html
+++ b/HTML/H90_example4.html
@@ -51,7 +51,7 @@
                 </li>
                 <li>iOS 10.2.1, Safari browser is based on the iOS version, VoiceOver on iPad 
                     <ul>
-                        <li>Result: iOS VoiceOver annouces </li>
+                        <li>Result: iOS VoiceOver announces </li>
                             <li>I am interested in the following required, main.</li>
                             <li>Photograph, checkbox, unchecked.</li>
                             <li>Watercolor, checkbox, checked.</li>

--- a/HTML/H91_example1a.html
+++ b/HTML/H91_example1a.html
@@ -43,7 +43,7 @@
                 </li>
                 <li>iOS 10.2.1, Safari browser is based on the iOS version, VoiceOver on iPad
                     <ul>
-                        <li>Result: iOS VoiceOver annouces example site link, end main.</li>
+                        <li>Result: iOS VoiceOver announces example site link, end main.</li>
                     </ul>
                 </li>
             </ul>

--- a/HTML/H91_example1b.html
+++ b/HTML/H91_example1b.html
@@ -43,7 +43,7 @@
                 </li>
                 <li>iOS 10.2.1, Safari browser is based on the iOS version, VoiceOver on iPad
                     <ul>
-                        <li>Result: iOS VoiceOver annouces example link, image, end main.</li>
+                        <li>Result: iOS VoiceOver announces example link, image, end main.</li>
                     </ul>
                 </li>
             </ul>

--- a/HTML/H91_example1c.html
+++ b/HTML/H91_example1c.html
@@ -43,7 +43,7 @@
                 </li>
                 <li>iOS 10.2.1, Safari browser is based on the iOS version, VoiceOver on iPad
                     <ul>
-                        <li>Result: iOS VoiceOver annouces example text link, end main.</li>
+                        <li>Result: iOS VoiceOver announces example text link, end main.</li>
                     </ul>
                 </li>
             </ul>

--- a/HTML/H91_example2a.html
+++ b/HTML/H91_example2a.html
@@ -43,7 +43,7 @@
                 </li>
                 <li>iOS 10.2.1, Safari browser is based on the iOS version, VoiceOver on iPad
                     <ul>
-                        <li>Result: iOS VoiceOver annouces save button, end main.</li>
+                        <li>Result: iOS VoiceOver announces save button, end main.</li>
                     </ul>
                 </li>
             </ul>

--- a/HTML/H91_example2b.html
+++ b/HTML/H91_example2b.html
@@ -45,7 +45,7 @@
                 </li>
                 <li>iOS 10.2.1, Safari browser is based on the iOS version, VoiceOver on iPad
                     <ul>
-                        <li>Result: iOS VoiceOver annouces save button, submit button, reset button, end main.</li>
+                        <li>Result: iOS VoiceOver announces save button, submit button, reset button, end main.</li>
                     </ul>
                 </li>
             </ul>

--- a/HTML/H91_example2c.html
+++ b/HTML/H91_example2c.html
@@ -43,7 +43,7 @@
                 </li>
                 <li>iOS 10.2.1, Safari browser is based on the iOS version, VoiceOver on iPad
                     <ul>
-                        <li>Result: iOS VoiceOver annouces save button, end main.</li>
+                        <li>Result: iOS VoiceOver announces save button, end main.</li>
                     </ul>
                 </li>
             </ul>

--- a/HTML/H91_example2d.html
+++ b/HTML/H91_example2d.html
@@ -43,7 +43,7 @@
                 </li>
                 <li>iOS 10.2.1, Safari browser is based on the iOS version, VoiceOver on iPad
                     <ul>
-                        <li>Result: iOS VoiceOver annouces save button, end main.</li>
+                        <li>Result: iOS VoiceOver announces save button, end main.</li>
                     </ul>
                 </li>
             </ul>

--- a/HTML/H91_example2e.html
+++ b/HTML/H91_example2e.html
@@ -43,7 +43,7 @@
                 </li>
                 <li>iOS 10.2.1, Safari browser is based on the iOS version, VoiceOver on iPad
                     <ul>
-                        <li>Result: iOS VoiceOver annouces sae button, end main.</li>
+                        <li>Result: iOS VoiceOver announces sae button, end main.</li>
                     </ul>
                 </li>
             </ul>

--- a/HTML/H91_example3a.html
+++ b/HTML/H91_example3a.html
@@ -44,7 +44,7 @@
                 </li>
                 <li>iOS 10.2.1, Safari browser is based on the iOS version, VoiceOver on iPad
                     <ul>
-                        <li>Result: iOS VoiceOver annouces type of fruit, bannas, text field, end main.</li>
+                        <li>Result: iOS VoiceOver announces type of fruit, bannas, text field, end main.</li>
                     </ul>
                 </li>
             </ul>

--- a/HTML/H91_example3b.html
+++ b/HTML/H91_example3b.html
@@ -43,7 +43,7 @@
                 </li>
                 <li>iOS 10.2.1, Safari browser is based on the iOS version, VoiceOver on iPad
                     <ul>
-                        <li>Result: iOS VoiceOver annouces type of fruit, text field, end main.</li>
+                        <li>Result: iOS VoiceOver announces type of fruit, text field, end main.</li>
                     </ul>
                 </li>
             </ul>

--- a/HTML/H91_example4.html
+++ b/HTML/H91_example4.html
@@ -44,7 +44,7 @@
                 </li>
                 <li>iOS 10.2.1, Safari browser is based on the iOS version, VoiceOver on iPad
                     <ul>
-                        <li>Result: iOS VoiceOver annouces cheese, checkbox checked, end main.</li>
+                        <li>Result: iOS VoiceOver announces cheese, checkbox checked, end main.</li>
                     </ul>
                 </li>
             </ul>

--- a/HTML/H91_example5.html
+++ b/HTML/H91_example5.html
@@ -45,7 +45,7 @@
                 </li>
                 <li>iOS 10.2.1, Safari browser is based on the iOS version, VoiceOver on iPad
                     <ul>
-                        <li>Result: iOS VoiceOver annouces red radio button checked 1 of 3, blue radio button unchecked, 2 of 3, 
+                        <li>Result: iOS VoiceOver announces red radio button checked 1 of 3, blue radio button unchecked, 2 of 3, 
                             green radio button unchecked 3 of 3.</li>
                     </ul>
                 </li>

--- a/HTML/H91_example6a.html
+++ b/HTML/H91_example6a.html
@@ -48,7 +48,7 @@
                 </li>
                 <li>iOS 10.2.1, Safari browser is based on the iOS version, VoiceOver on iPad
                     <ul>
-                        <li>Result: iOS VoiceOver annouces </li>
+                        <li>Result: iOS VoiceOver announces </li>
                             <ul>
                                <li>Number one pop-up button, double tap to activate the picker.</li>
                                 <li>Combo box selection pop-up iOS VoiceOver announces selected two.

--- a/HTML/H91_example6b.html
+++ b/HTML/H91_example6b.html
@@ -47,7 +47,7 @@
                 </li>
                 <li>iOS 10.2.1, Safari browser is based on the iOS version, VoiceOver on iPad
                     <ul>
-                        <li>Result: iOS VoiceOver annouces </li>
+                        <li>Result: iOS VoiceOver announces </li>
                             <ul>
                                <li>Number one pop-up button, double tap to activate the picker.</li>
                                 <li>Combo box selection pop-up iOS VoiceOver announces selected two.

--- a/HTML/H91_example7a.html
+++ b/HTML/H91_example7a.html
@@ -44,7 +44,7 @@
                 </li>
                 <li>iOS 10.2.1, Safari browser is based on the iOS version, VoiceOver on iPad
                     <ul>
-                        <li>Result: iOS VoiceOver annouces type your speech here, four score and seven years ago, 
+                        <li>Result: iOS VoiceOver announces type your speech here, four score and seven years ago, 
                             multi-lines text field, end main, double tap to edit.</li>
                     </ul>
                 </li>

--- a/HTML/H91_example7b.html
+++ b/HTML/H91_example7b.html
@@ -43,7 +43,7 @@
                 </li>
                 <li>iOS 10.2.1, Safari browser is based on the iOS version, VoiceOver on iPad
                     <ul>
-                        <li>Result: iOS VoiceOver annouces type your speech here, four score and seven years ago, 
+                        <li>Result: iOS VoiceOver announces type your speech here, four score and seven years ago, 
                             multi-lines text field, end main, double tap to edit.</li>
                     </ul>
                 </li>

--- a/HTML/H97_example1.html
+++ b/HTML/H97_example1.html
@@ -44,7 +44,7 @@
                 </li>
 		<li>iOS 10.2.1, Safari browser is based on the iOS version, VoiceOver on iPad
                     <ul>
-                        <li>Result: iOS VoiceOver annouces </li>
+                        <li>Result: iOS VoiceOver announces </li>
 			    <ul>
 				<li>Web accessiblity link, secondary, navigation landmark. </li>
 				<li>Document accessiblity link.</li>

--- a/HTML/H97_example2.html
+++ b/HTML/H97_example2.html
@@ -55,7 +55,7 @@
                 </li>
 		<li>iOS 10.2.1, Safari browser is based on the iOS version, VoiceOver on iPad
                     <ul>
-                        <li>Result: iOS VoiceOver annouces </li>
+                        <li>Result: iOS VoiceOver announces </li>
 			    <ul>
 				<li>Bullet, list start, landmark, lemons link.</li>
 				<li>Bullet, organges link.</li>   

--- a/HTML/H97_example3.html
+++ b/HTML/H97_example3.html
@@ -50,7 +50,7 @@
                 </li>
 		<li>iOS 10.2.1, Safari browser is based on the iOS version, VoiceOver on iPad
                     <ul>
-                        <li>Result: iOS VoiceOver annouces </li>
+                        <li>Result: iOS VoiceOver announces </li>
 			    <ul>
 				<li>Home link, primary navigation landmark.</li>
 				<li>About us link.</li>


### PR DESCRIPTION
Several HTML techniques pages were updated with iOS test results, but they had a typo on the word "announces".  Used perl to do a quick find / replace to fix.

perl -pi -w -e 's/annouces/announces/g;' *.html