### PR TITLE
Added tabindex to checkbox

### DIFF
--- a/ARIA/aria-checkbox.html
+++ b/ARIA/aria-checkbox.html
@@ -35,7 +35,7 @@
     <main role="main">
         <h1>ARIA Checkbox</h1>
         <!-- Component start -->
-        <div onclick="togglePressed()" role="checkbox" aria-checked="false" id="aria-checkbox"><img id="checkboxImg" src="http://www.oaa-accessibility.org/media/examples/images/checkbox-unchecked-black.png" alt="" role="presentation"> </div>
+        <div onclick="togglePressed()" tabindex="0" role="checkbox" aria-checked="false" id="aria-checkbox"><img id="checkboxImg" src="http://www.oaa-accessibility.org/media/examples/images/checkbox-unchecked-black.png" alt="" role="presentation"> </div>
         <p id="checkboxResponse">Box not checked</p>
         <!-- Component end -->
     </main>


### PR DESCRIPTION
without a tabindex, this widget would never receive focus for JAWS to be able to read it out or interact with it