### PR TITLE
Fix links to GitHub sources

### DIFF
--- a/WCAG_ARIA/ARIA1_example1.html
+++ b/WCAG_ARIA/ARIA1_example1.html
@@ -17,7 +17,7 @@
         <hr>
     </header>
     <main role="main">
-        <h1>ARIA1 - Example 1: Using the aria-describedby property to provide a descriptive label for user interface controls</h1>
+        <h1>ARIA1 - Example 1: Using aria-describedby property to describe a Close button's action</h1>
         <!-- Component start -->
 
         <button aria-label="Close" aria-describedby="descriptionClose" onclick="window.close()">X</button>
@@ -32,8 +32,17 @@
         <!-- Enter any references or sources using the format example below. 
              If this is an original code sample you can just delete the Source: line below
         -->
-        <p>Source: <a href="https://www.w3.org/TR/WCAG20-TECHS/aria.html#ARIA1" target="_blank">ARIA1</a></p>
-        <p><a href="https://github.com/IBMa/Va11yS/blob/master/ARIA/ARIA1_example1.html" target="_blank">View code</a> on GitHub</p>
+        <h3>Source: </h3>
+        <p>
+            <ul>
+                <li>
+                    <a href="https://www.w3.org/TR/WCAG20-TECHS/aria.html#ARIA1" target="_blank">WCAG ARIA1: Using the aria-describedby property to provide a descriptive label for user interface controls</a>
+                </li>
+                <li>
+                    <a href="https://github.com/IBMa/Va11yS/blob/master/WCAG_ARIA/ARIA1_example1.html" target="_blank">Source code on GitHub</a>
+                </li>
+            </ul>
+        </p>
         <!-- Enter testing results following examples below.  Include:  OS, Browser, AT used, and result -->
         <h3>Tested on:</h3>
         <div>

--- a/WCAG_ARIA/ARIA1_example1.html
+++ b/WCAG_ARIA/ARIA1_example1.html
@@ -33,7 +33,7 @@
              If this is an original code sample you can just delete the Source: line below
         -->
         <h3>Source: </h3>
-        <p>
+        <div>
             <ul>
                 <li>
                     <a href="https://www.w3.org/TR/WCAG20-TECHS/aria.html#ARIA1" target="_blank">WCAG ARIA1: Using the aria-describedby property to provide a descriptive label for user interface controls</a>
@@ -42,7 +42,7 @@
                     <a href="https://github.com/IBMa/Va11yS/blob/master/WCAG_ARIA/ARIA1_example1.html" target="_blank">Source code on GitHub</a>
                 </li>
             </ul>
-        </p>
+        </div>
         <!-- Enter testing results following examples below.  Include:  OS, Browser, AT used, and result -->
         <h3>Tested on:</h3>
         <div>

--- a/WCAG_ARIA/ARIA1_example2.html
+++ b/WCAG_ARIA/ARIA1_example2.html
@@ -37,7 +37,7 @@
              If this is an original code sample you can just delete the Source: line below
         -->
         <h3>Source:</h3>
-        <p>
+        <div>
             <ul>
                 <li>
                     <a href="https://www.w3.org/TR/WCAG20-TECHS/aria.html#ARIA1" target="_blank">WCAG ARIA1: Using the aria-describedby property to provide a descriptive label for user interface controls</a>
@@ -46,7 +46,7 @@
                     <a href="https://github.com/IBMa/Va11yS/blob/master/WCAG_ARIA/ARIA1_example2.html" target="_blank">Source code on GitHub</a>
                 </li>
             </ul>
-        </p>
+        </div>
         <!-- Enter testing results following examples below.  Include:  OS, Browser, AT used, and result -->
         <h3>Tested on:</h3>
         <div>

--- a/WCAG_ARIA/ARIA1_example2.html
+++ b/WCAG_ARIA/ARIA1_example2.html
@@ -47,7 +47,6 @@
                 </li>
             </ul>
         </p>
-
         <!-- Enter testing results following examples below.  Include:  OS, Browser, AT used, and result -->
         <h3>Tested on:</h3>
         <div>

--- a/WCAG_ARIA/ARIA1_example2.html
+++ b/WCAG_ARIA/ARIA1_example2.html
@@ -17,7 +17,7 @@
         <hr>
     </header>
     <main role="main">
-        <h1>ARIA1 - Example 2: Using the aria-describedby property to provide a descriptive label for user interface controls</h1>
+        <h1>ARIA1 - Example 2: Using aria-describedby to associate instructions with form fields</h1>
         <!-- Component start -->
 
         <form>
@@ -36,8 +36,17 @@
         <!-- Enter any references or sources using the format example below. 
              If this is an original code sample you can just delete the Source: line below
         -->
-        <p>Source: <a href="https://www.w3.org/TR/WCAG20-TECHS/aria.html#ARIA1" target="_blank">ARIA1</a></p>
-        <p><a href="https://github.com/IBMa/Va11yS/blob/master/ARIA/ARIA1_example2.html" target="_blank">View code</a> on GitHub</p>
+        <h3>Source:</h3>
+        <p>
+            <ul>
+                <li>
+                    <a href="https://www.w3.org/TR/WCAG20-TECHS/aria.html#ARIA1" target="_blank">WCAG ARIA1: Using the aria-describedby property to provide a descriptive label for user interface controls</a>
+                </li>
+                <li>
+                    <a href="https://github.com/IBMa/Va11yS/blob/master/WCAG_ARIA/ARIA1_example2.html" target="_blank">Source code on GitHub</a>
+                </li>
+            </ul>
+        </p>
 
         <!-- Enter testing results following examples below.  Include:  OS, Browser, AT used, and result -->
         <h3>Tested on:</h3>

--- a/WCAG_ARIA/ARIA2_example1.html
+++ b/WCAG_ARIA/ARIA2_example1.html
@@ -42,7 +42,7 @@
              If this is an original code sample you can just delete the Source: line below
         -->
         <h3>Source: </h3>
-        <p>
+        <div>
             <ul>
                 <li>
                     <a href="https://www.w3.org/TR/WCAG20-TECHS/aria.html#ARIA2" target="_blank">WCAG ARIA2: Identifying a required field with the <code>aria-required</code> property</a>
@@ -51,7 +51,7 @@
                     <a href="https://github.com/IBMa/Va11yS/blob/master/WCAG_ARIA/ARIA2_example1.html" target="_blank">Source code on GitHub</a> 
                 </li>
             </ul>
-        </p> 
+        </div> 
         <!-- Enter testing results following examples below.  Include:  OS, Browser, AT used, and result -->
         <h3>Tested on:</h3>
         <div>

--- a/WCAG_ARIA/ARIA2_example1.html
+++ b/WCAG_ARIA/ARIA2_example1.html
@@ -41,8 +41,17 @@
         <!-- Enter any references or sources using the format example below. 
              If this is an original code sample you can just delete the Source: line below
         -->
-        <p>WCAG Source: <a href="https://www.w3.org/TR/WCAG20-TECHS/aria.html#ARIA2" target="_blank">ARIA2</a></p>
-        <p><a href="https://github.com/IBMa/Va11yS/blob/master/ARIA/ARIA2_example1.html" target="_blank">View code</a> on GitHub</p>
+        <h3>Source: </h3>
+        <p>
+            <ul>
+                <li>
+                    <a href="https://www.w3.org/TR/WCAG20-TECHS/aria.html#ARIA2" target="_blank">WCAG ARIA2: Identifying a required field with the <code>aria-required</code> property</a>
+                </li>
+                <li>
+                    <a href="https://github.com/IBMa/Va11yS/blob/master/WCAG_ARIA/ARIA2_example1.html" target="_blank">Source code on GitHub</a> 
+                </li>
+            </ul>
+        </p> 
         <!-- Enter testing results following examples below.  Include:  OS, Browser, AT used, and result -->
         <h3>Tested on:</h3>
         <div>

--- a/WCAG_GENERAL/G55_example1.html
+++ b/WCAG_GENERAL/G55_example1.html
@@ -44,14 +44,14 @@
              If this is an original code sample you can just delete the Source: line below
         -->
         <h3>Source: </h3>
-        <p>
+        <div>
             <ul>
                 <li><a href="https://www.w3.org/TR/WCAG20-TECHS/general.html#G55" target="_blank">WCAG G55: Linking to definitions</a></li>
                 <li><a href="https://github.com/IBMa/Va11yS/blob/master/WCAG_GENERAL/G55_example1.html" target="_blank">Source Code on GitHub</a></li>
                 <li><a href="http://www.dictionary.com/browse/rugby" target="_blank">Rugby definition on Dictionary.com</a></li>
                 <li><a href="https://www.merriam-webster.com/medical" target="_blank">Merriam-Webster Medical Dictionary</a></li>
             </ul>
-        </p>
+        </div>
         <!-- Enter testing results following examples below.  Include:  OS, Browser, AT used, and result -->
         <h3>Tested on:</h3>
         <div>

--- a/WCAG_GENERAL/G55_example1.html
+++ b/WCAG_GENERAL/G55_example1.html
@@ -4,7 +4,7 @@
 <head>
     <meta name="viewport" content="width=device-width, minimal-ui">
     <meta charset="utf-8">
-    <link rel="stylesheet" type="text/css" href="../css/style.css">    
+    <link rel="stylesheet" type="text/css" href="../css/style.css">
     <title>G55 Example 1</title>
 </head>
 
@@ -17,21 +17,23 @@
         <hr>
     </header>
     <main role="main">
-        <h1>G55 Example 1: Technical terms and abbreviations in an article about sports injuries are linked to definitions in a medical dictionary</h1>
+        <h1>G55 Example 1: Technical terms and abbreviations in an article about sports injuries are linked to definitions in
+            a medical dictionary</h1>
         <!-- Component start -->
-        <p>This is an example of technical terms and abbreviations that could be used in an article about sports 
-        injuries. The types of injuries are linked to definitions in a medical dictionary.</p>
+        <p>This is an example of technical terms and abbreviations that could be used in an article about sports injuries. The
+            types of injuries are linked to definitions in a medical dictionary.</p>
 
-        <p><a href="http://www.dictionary.com/browse/rugby">Rugby</a> football, which is also known as Rugger is played between 2 teams with 15 members on each team.
-        It is similiar to soccer with the exception that players are allowed to carry the ball. Players are also
-        allowed to block and tackle. There are no player substitutions, so each player must participant in the entire
-        game.</p>
-        
+        <p><a href="http://www.dictionary.com/browse/rugby">Rugby</a> football, which is also known as Rugger is played between
+            2 teams with 15 members on each team. It is similiar to soccer with the exception that players are allowed to
+            carry the ball. Players are also allowed to block and tackle. There are no player substitutions, so each player
+            must participant in the entire game.
+        </p>
+
         <p>The most common injuries associated with Rugby football are <a href="https://www.merriam-webster.com/dictionary/strain#medicalDictionary">
          muscular strains</a> and <a href="https://www.merriam-webster.com/dictionary/sprain#medicalDictionary">sprains</a>.
-        Other injuries that frequently occur are <a href="https://www.merriam-webster.com/dictionary/dislocation#medicalDictionary">joint dislocations</a>, 
-        <a href="https://www.merriam-webster.com/dictionary/fracture#medicalDictionary">bone fractures</a>, and 
-        <a href="https://www.merriam-webster.com/dictionary/laceration#medicalDictionary">lacerations</a>.</p>
+            Other injuries that frequently occur are <a href="https://www.merriam-webster.com/dictionary/dislocation#medicalDictionary">joint dislocations</a>,
+            <a href="https://www.merriam-webster.com/dictionary/fracture#medicalDictionary">bone fractures</a>, and
+            <a href="https://www.merriam-webster.com/dictionary/laceration#medicalDictionary">lacerations</a>.</p>
 
         <!-- Component end -->
     </main>
@@ -41,12 +43,13 @@
         <!-- Enter any references or sources using the format example below. 
              If this is an original code sample you can just delete the Source: line below
         -->
-        <p>Source:
-            <ul> 
-            <li><a href="https://www.w3.org/TR/WCAG20-TECHS/general.html#G55" target="_blank">WCAG G55: Linking to definitions</a></li>
-            <li><a href="https://github.com/IBMa/Va11yS/blob/master/GENERAL/G55_example1.html" target="_blank">Source Code on GitHub</a></li>
-            <li><a href="http://www.dictionary.com/browse/rugby" target="_blank">Rugby definition on Dictionary.com</a></li>
-            <li><a href="https://www.merriam-webster.com/medical" target="_blank">Merriam-Webster Medical Dictionary</a></li>
+        <h3>Source: </h3>
+        <p>
+            <ul>
+                <li><a href="https://www.w3.org/TR/WCAG20-TECHS/general.html#G55" target="_blank">WCAG G55: Linking to definitions</a></li>
+                <li><a href="https://github.com/IBMa/Va11yS/blob/master/WCAG_GENERAL/G55_example1.html" target="_blank">Source Code on GitHub</a></li>
+                <li><a href="http://www.dictionary.com/browse/rugby" target="_blank">Rugby definition on Dictionary.com</a></li>
+                <li><a href="https://www.merriam-webster.com/medical" target="_blank">Merriam-Webster Medical Dictionary</a></li>
             </ul>
         </p>
         <!-- Enter testing results following examples below.  Include:  OS, Browser, AT used, and result -->
@@ -55,8 +58,8 @@
             <ul>
                 <li>Windows 7, Firefox ESR 49.0.1, and JAWS 17
                     <ul>
-                        <li>Result: Screen reader announces the link text for each injury. Links open to the defintions 
-                        in a separate window.
+                        <li>Result: Screen reader announces the link text for each injury. Links open to the defintions in a
+                            separate window.
                         </li>
                     </ul>
                 </li>

--- a/WCAG_GENERAL/G58_example1.html
+++ b/WCAG_GENERAL/G58_example1.html
@@ -32,13 +32,13 @@
              If this is an original code sample you can just delete the Source: line below
         -->
         <h3>Source:</h3>
-        <p>
+        <div>
             <ul>
                 <li><a href="https://www.w3.org/TR/WCAG20-TECHS/general.html#G58" target="_blank">WCAG G58: Placing a link to the alternative for time-based media immediately next to the 
         non-text content</a></li>
                 <li><a href="https://github.com/IBMa/Va11yS/blob/master/WCAG_GENERAL/G58_example1.html" target="_blank">Source Code on GitHub</a></li>
             </ul>
-        </p>
+        </div>
         <!-- Enter testing results following examples below.  Include:  OS, Browser, AT used, and result -->
         <h3>Tested on:</h3>
         <div>

--- a/WCAG_GENERAL/G58_example1.html
+++ b/WCAG_GENERAL/G58_example1.html
@@ -4,7 +4,7 @@
 <head>
     <meta name="viewport" content="width=device-width, minimal-ui">
     <meta charset="utf-8">
-    <link rel="stylesheet" type="text/css" href="../css/style.css">    
+    <link rel="stylesheet" type="text/css" href="../css/style.css">
     <title>G58 Example 1</title>
 </head>
 
@@ -20,8 +20,8 @@
         <h1>G58 Example 1: A wrestling video and transcript</h1>
         <!-- Component start -->
         <a name="Olympic_Wrestling"></a>
-        <p><a href="https://youtu.be/3dV_z4Vy0xQ" target="_blank">WWE - Cesaro vents about Raw management: July 19, 2016</a> Video, 
-        transcript provided by <a href="https://prowrestlingpress.com/2016/07/21/video-and-transcript-of-cesaro-shoot-promo-on-raw-and-mcmahon-storylines/" target="_blank">
+        <p><a href="https://youtu.be/3dV_z4Vy0xQ" target="_blank">WWE - Cesaro vents about Raw management: July 19, 2016</a>            Video, transcript provided by <a href="https://prowrestlingpress.com/2016/07/21/video-and-transcript-of-cesaro-shoot-promo-on-raw-and-mcmahon-storylines/"
+                target="_blank">
         Pro Wrestling Press</a>.</p>
         <!-- Component end -->
     </main>
@@ -31,12 +31,13 @@
         <!-- Enter any references or sources using the format example below. 
              If this is an original code sample you can just delete the Source: line below
         -->
-        <p>Source: 
+        <h3>Source:</h3>
+        <p>
             <ul>
                 <li><a href="https://www.w3.org/TR/WCAG20-TECHS/general.html#G58" target="_blank">WCAG G58: Placing a link to the alternative for time-based media immediately next to the 
         non-text content</a></li>
-                <li><a href="https://github.com/IBMa/Va11yS/blob/master/GENERAL/G58_example1.html" target="_blank">Source Code on GitHub</a></li>
-           </ul>
+                <li><a href="https://github.com/IBMa/Va11yS/blob/master/WCAG_GENERAL/G58_example1.html" target="_blank">Source Code on GitHub</a></li>
+            </ul>
         </p>
         <!-- Enter testing results following examples below.  Include:  OS, Browser, AT used, and result -->
         <h3>Tested on:</h3>

--- a/WCAG_GENERAL/G65_example1.html
+++ b/WCAG_GENERAL/G65_example1.html
@@ -4,7 +4,7 @@
 <head>
     <meta name="viewport" content="width=device-width, minimal-ui">
     <meta charset="utf-8">
-    <link rel="stylesheet" type="text/css" href="../css/style.css">    
+    <link rel="stylesheet" type="text/css" href="../css/style.css">
     <title>G65 Example 1</title>
 </head>
 
@@ -28,10 +28,11 @@
         <!-- Enter any references or sources using the format example below. 
              If this is an original code sample you can just delete the Source: line below
         -->
-        <p>Source: 
+        <h3>Source:</h3>
+        <p>
             <ul>
-              <li><a href="https://www.w3.org/TR/WCAG20-TECHS/general.html#G65" target="_blank">WCAG G65: Providing a breadcrumb trail</a></li>
-              <li><a href="https://github.com/IBMa/Va11yS/blob/master/GENERAL/G70_example1.html" target="_blank">Source Code on GitHub</a></li>
+                <li><a href="https://www.w3.org/TR/WCAG20-TECHS/general.html#G65" target="_blank">WCAG G65: Providing a breadcrumb trail</a></li>
+                <li><a href="https://github.com/IBMa/Va11yS/blob/master/WCAG_GENERAL/G65_example1.html" target="_blank">Source Code on GitHub</a></li>
             </ul>
         </p>
         <!-- Enter testing results following examples below.  Include:  OS, Browser, AT used, and result -->

--- a/WCAG_GENERAL/G65_example1.html
+++ b/WCAG_GENERAL/G65_example1.html
@@ -29,12 +29,12 @@
              If this is an original code sample you can just delete the Source: line below
         -->
         <h3>Source:</h3>
-        <p>
+        <div>
             <ul>
                 <li><a href="https://www.w3.org/TR/WCAG20-TECHS/general.html#G65" target="_blank">WCAG G65: Providing a breadcrumb trail</a></li>
                 <li><a href="https://github.com/IBMa/Va11yS/blob/master/WCAG_GENERAL/G65_example1.html" target="_blank">Source Code on GitHub</a></li>
             </ul>
-        </p>
+        </div>
         <!-- Enter testing results following examples below.  Include:  OS, Browser, AT used, and result -->
         <h3>Tested on:</h3>
         <div>

--- a/WCAG_GENERAL/G70_example1.html
+++ b/WCAG_GENERAL/G70_example1.html
@@ -37,12 +37,13 @@
         <!-- Enter any references or sources using the format example below. 
              If this is an original code sample you can just delete the Source: line below
         -->
-        <p>Source: 
+        <h3>Source:</h3> 
+        <div>
             <ul>
                 <li><a href="https://www.w3.org/TR/WCAG20-TECHS/general.html#G70" target="_blank">WCAG G70: Providing a function to search an online dictionary</a></li>
-                <li><a href="https://github.com/IBMa/Va11yS/blob/master/GENERAL/G70_example1.html" target="_blank">Source Code on GitHub</a></li>
+                <li><a href="https://github.com/IBMa/Va11yS/blob/master/WCAG_GENERAL/G70_example1.html" target="_blank">Source Code on GitHub</a></li>
             </ul>
-        </p>
+        </div>
         <!-- Enter testing results following examples below.  Include:  OS, Browser, AT used, and result -->
         <h3>Tested on:</h3>
         <div>

--- a/WCAG_GENERAL/G71_example1.html
+++ b/WCAG_GENERAL/G71_example1.html
@@ -4,8 +4,8 @@
 <head>
     <meta name="viewport" content="width=device-width, minimal-ui">
     <meta charset="utf-8">
-    <link rel="stylesheet" type="text/css" href="../css/style.css">  
-     <link rel="stylesheet" type="text/css" href="css/style_G70.css">    
+    <link rel="stylesheet" type="text/css" href="../css/style.css">
+    <link rel="stylesheet" type="text/css" href="css/style_G70.css">
     <title>G71 Example 1</title>
 </head>
 
@@ -35,10 +35,11 @@
         <!-- Enter any references or sources using the format example below. 
              If this is an original code sample you can just delete the Source: line below
         -->
-        <p>Source: 
+        <h3>Source:</h3>
+        <p>
             <ul>
                 <li><a href="https://www.w3.org/TR/WCAG20-TECHS/general.html#G71" target="_blank">WCAG G71: Providing a help link on every Web page</a></li>
-                <li><a href="https://github.com/IBMa/Va11yS/blob/master/GENERAL/G71_example1.html" target="_blank">Source Code on GitHub</a></li>
+                <li><a href="https://github.com/IBMa/Va11yS/blob/master/WCAG_GENERAL/G71_example1.html" target="_blank">Source Code on GitHub</a></li>
             </ul>
         </p>
         <!-- Enter testing results following examples below.  Include:  OS, Browser, AT used, and result -->

--- a/WCAG_GENERAL/G71_example1.html
+++ b/WCAG_GENERAL/G71_example1.html
@@ -36,12 +36,12 @@
              If this is an original code sample you can just delete the Source: line below
         -->
         <h3>Source:</h3>
-        <p>
+        <div>
             <ul>
                 <li><a href="https://www.w3.org/TR/WCAG20-TECHS/general.html#G71" target="_blank">WCAG G71: Providing a help link on every Web page</a></li>
                 <li><a href="https://github.com/IBMa/Va11yS/blob/master/WCAG_GENERAL/G71_example1.html" target="_blank">Source Code on GitHub</a></li>
             </ul>
-        </p>
+        </div>
         <!-- Enter testing results following examples below.  Include:  OS, Browser, AT used, and result -->
         <h3>Tested on:</h3>
         <div>

--- a/WCAG_GENERAL/G73_example1.html
+++ b/WCAG_GENERAL/G73_example1.html
@@ -36,13 +36,13 @@
              If this is an original code sample you can just delete the Source: line below
         -->
         <h3>Source:</h3>
-        <p>
+        <div>
             <ul>
                 <li><a href="https://www.w3.org/TR/WCAG20-TECHS/general.html#G73" target="_blank">WCAG G73: Providing a long description in another location 
             with a link to it that is immediately adjacent to the non-text content</a></li>
                 <li><a href="https://github.com/IBMa/Va11yS/blob/master/WCAG_GENERAL/G73_example1.html" target="_blank">Source Code on GitHub</a></li>
             </ul>
-        </p>
+        </div>
         <!-- Enter testing results following examples below.  Include:  OS, Browser, AT used, and result -->
         <h3>Tested on:</h3>
         <div>

--- a/WCAG_GENERAL/G73_example1.html
+++ b/WCAG_GENERAL/G73_example1.html
@@ -4,7 +4,7 @@
 <head>
     <meta name="viewport" content="width=device-width, minimal-ui">
     <meta charset="utf-8">
-    <link rel="stylesheet" type="text/css" href="../css/style.css">    
+    <link rel="stylesheet" type="text/css" href="../css/style.css">
     <title>G73 Example 1</title>
 </head>
 
@@ -24,7 +24,8 @@
         <img src="img/description.jpg" alt="Long Description" longdesc="G73_example1.html#sales">
         <br>
         <div id="sales">
-            Sales for October show Salesperson 1 is leading with $43,000. Salesperson 2 follows closely with $42,000. Salesperson 3 rounds out our top 3 with sales of $41,000. [Long Descritpion] 
+            Sales for October show Salesperson 1 is leading with $43,000. Salesperson 2 follows closely with $42,000. Salesperson 3 rounds
+            out our top 3 with sales of $41,000. [Long Descritpion]
         </div>
         <!-- Component end -->
     </main>
@@ -34,11 +35,12 @@
         <!-- Enter any references or sources using the format example below. 
              If this is an original code sample you can just delete the Source: line below
         -->
-        <p>Source:
-            <ul> 
-            <li><a href="https://www.w3.org/TR/WCAG20-TECHS/general.html#G73" target="_blank">WCAG G73: Providing a long description in another location 
+        <h3>Source:</h3>
+        <p>
+            <ul>
+                <li><a href="https://www.w3.org/TR/WCAG20-TECHS/general.html#G73" target="_blank">WCAG G73: Providing a long description in another location 
             with a link to it that is immediately adjacent to the non-text content</a></li>
-            <li><a href="https://github.com/IBMa/Va11yS/blob/master/GENERAL/G73_example1.html" target="_blank">Source Code on GitHub</a></li>
+                <li><a href="https://github.com/IBMa/Va11yS/blob/master/WCAG_GENERAL/G73_example1.html" target="_blank">Source Code on GitHub</a></li>
             </ul>
         </p>
         <!-- Enter testing results following examples below.  Include:  OS, Browser, AT used, and result -->

--- a/WCAG_GENERAL/G74_example1.html
+++ b/WCAG_GENERAL/G74_example1.html
@@ -36,13 +36,13 @@
              If this is an original code sample you can just delete the Source: line below
         -->
         <h3>Source:</h3>
-        <p>
+        <div>
             <ul>
                 <li><a href="https://www.w3.org/TR/WCAG20-TECHS/general.html#G74" target="_blank">WCAG G74: Providing a long description in text near the non-text content, with a reference to the 
             location of the long description in the short description</a></li>
                 <li><a href="https://github.com/IBMa/Va11yS/blob/master/WCAG_GENERAL/G74_example1.html" target="_blank">Source Code on GitHub</a></li>
             </ul>
-        </p>
+        </div>
         <!-- Enter testing results following examples below.  Include:  OS, Browser, AT used, and result -->
         <h3>Tested on:</h3>
         <div>

--- a/WCAG_GENERAL/G74_example1.html
+++ b/WCAG_GENERAL/G74_example1.html
@@ -4,7 +4,7 @@
 <head>
     <meta name="viewport" content="width=device-width, minimal-ui">
     <meta charset="utf-8">
-    <link rel="stylesheet" type="text/css" href="../css/style.css">    
+    <link rel="stylesheet" type="text/css" href="../css/style.css">
     <title>G74 Example 1</title>
 </head>
 
@@ -17,13 +17,15 @@
         <hr>
     </header>
     <main role="main">
-        <h1>G74 Example 1: A bar chart on a Web page showing the sales for the top three salespeople that includes a long description after the chart</h1>
+        <h1>G74 Example 1: A bar chart on a Web page showing the sales for the top three salespeople that includes a long description
+            after the chart</h1>
         <!-- Component start -->
         <h2>October Sales</h2>
         <img src="img/sales.jpg" alt="October sales chart for top three salespeople. Details in text following the chart:">
         <br>
         <div id="sales">
-            Sales for October show Salesperson 1 is leading with $43,000. Salesperson 2 follows closely with $42,000. Salesperson 3 rounds out our top 3 with sales of $41,000. 
+            Sales for October show Salesperson 1 is leading with $43,000. Salesperson 2 follows closely with $42,000. Salesperson 3 rounds
+            out our top 3 with sales of $41,000.
         </div>
         <!-- Component end -->
     </main>
@@ -33,11 +35,12 @@
         <!-- Enter any references or sources using the format example below. 
              If this is an original code sample you can just delete the Source: line below
         -->
-        <p>Source:
-            <ul> 
-            <li><a href="https://www.w3.org/TR/WCAG20-TECHS/general.html#G74" target="_blank">WCAG G74: Providing a long description in text near the non-text content, with a reference to the 
+        <h3>Source:</h3>
+        <p>
+            <ul>
+                <li><a href="https://www.w3.org/TR/WCAG20-TECHS/general.html#G74" target="_blank">WCAG G74: Providing a long description in text near the non-text content, with a reference to the 
             location of the long description in the short description</a></li>
-            <li><a href="https://github.com/IBMa/Va11yS/blob/master/GENERAL/G74_example1.html" target="_blank">Source Code on GitHub</a></li>
+                <li><a href="https://github.com/IBMa/Va11yS/blob/master/WCAG_GENERAL/G74_example1.html" target="_blank">Source Code on GitHub</a></li>
             </ul>
         </p>
         <!-- Enter testing results following examples below.  Include:  OS, Browser, AT used, and result -->

--- a/WCAG_GENERAL/G80_example1.html
+++ b/WCAG_GENERAL/G80_example1.html
@@ -4,10 +4,10 @@
 <head>
     <meta name="viewport" content="width=device-width, minimal-ui">
     <meta charset="utf-8">
-    <link rel="stylesheet" type="text/css" href="../css/style.css">    
-    <script LANGUAGE="JavaScript" type="text/javascript">
+    <link rel="stylesheet" type="text/css" href="../css/style.css">
+    <script language="JavaScript" type="text/javascript">
         function displaytext() {
-            DispWin = window.open('','NewWin', 'toolbar=no,status=no,width=400,height=200')
+            DispWin = window.open('', 'NewWin', 'toolbar=no,status=no,width=400,height=200')
             message = "<ul><li><b>First Name: </b>" + document.phonebook.first.value;
             message += "<li><b>Last Name: </b>" + document.phonebook.last.value;
             message += "<li><b>Phone Number: </b>" + document.phonebook.phone.value;
@@ -36,7 +36,8 @@
             </p>
             <p><label for="phone">Phone Number: </label> <input type="text" size="15" name="phone" id="phone">
             </p>
-            <input type="submit" value="Submit" onClick="displaytext();">
+            <input type="submit" value="Submit" onclick="displaytext();">
+        </form>
 
         <!-- Component end -->
     </main>
@@ -46,10 +47,11 @@
         <!-- Enter any references or sources using the format example below. 
              If this is an original code sample you can just delete the Source: line below
         -->
-        <p>Source:
-            <ul> 
-            <li><a href="https://www.w3.org/TR/WCAG20-TECHS/general.html#G80" target="_blank">WCAG G80: Providing a submit button to initiate a change of context</a></li>
-            <li><a href="https://github.com/IBMa/Va11yS/blob/master/GENERAL/G80_example1.html" target="_blank">Source Code on GitHub</a></li>
+        <h3>Source:</h3>
+        <p>
+            <ul>
+                <li><a href="https://www.w3.org/TR/WCAG20-TECHS/general.html#G80" target="_blank">WCAG G80: Providing a submit button to initiate a change of context</a></li>
+                <li><a href="https://github.com/IBMa/Va11yS/blob/master/WCAG_GENERAL/G80_example1.html" target="_blank">Source Code on GitHub</a></li>
             </ul>
         </p>
         <!-- Enter testing results following examples below.  Include:  OS, Browser, AT used, and result -->

--- a/WCAG_GENERAL/G80_example1.html
+++ b/WCAG_GENERAL/G80_example1.html
@@ -48,12 +48,12 @@
              If this is an original code sample you can just delete the Source: line below
         -->
         <h3>Source:</h3>
-        <p>
+        <div>
             <ul>
                 <li><a href="https://www.w3.org/TR/WCAG20-TECHS/general.html#G80" target="_blank">WCAG G80: Providing a submit button to initiate a change of context</a></li>
                 <li><a href="https://github.com/IBMa/Va11yS/blob/master/WCAG_GENERAL/G80_example1.html" target="_blank">Source Code on GitHub</a></li>
             </ul>
-        </p>
+        </div>
         <!-- Enter testing results following examples below.  Include:  OS, Browser, AT used, and result -->
         <h3>Tested on:</h3>
         <div>

--- a/WCAG_GENERAL/G85_example1.html
+++ b/WCAG_GENERAL/G85_example1.html
@@ -6,17 +6,17 @@
     <meta charset="utf-8">
     <link rel="stylesheet" type="text/css" href="../css/style.css">
     <script>
-        function validate(phone){
-            var num = phone.value.replace(/[^\d]/g,'');
-                if(num.length != 10) {
-                alert('You must enter a valid 10 digit phone number');                   
-                } 
-        }   
-    </script>    
+        function validate(phone) {
+            var num = phone.value.replace(/[^\d]/g, '');
+            if (num.length != 10) {
+                alert('You must enter a valid 10 digit phone number');
+            }
+        }
+    </script>
     <title>G85 Example 1</title>
 </head>
 
-<body onload='document.phonebook.phone.focus()'>
+<body onload="document.phonebook.phone.focus()">
     <!-- Header w/ breadcrumb (Adjust breadcrumb links as needed) -->
     <header role="banner" id="primary">
         <nav role="navigation">
@@ -25,12 +25,14 @@
         <hr>
     </header>
     <main role="main">
-        <h1>G85 Example 1: When a user inputs invalid data on a form field an alert dialog appears upon exiting the field or submitting the form</h1>
+        <h1>G85 Example 1: When a user inputs invalid data on a form field an alert dialog appears upon exiting the field or
+            submitting the form</h1>
         <!-- Component start -->
         <form name="phonebook" action="#">
             <p><label for="phone">Enter a 10 digit phone Number: </label> <input type="text" size="20" name="phone" id="phone">
             </p>
             <input type="submit" value="Submit" onclick="validate(phone)">
+        </form>
         <!-- Component end -->
     </main>
     <footer role="contentinfo">
@@ -39,11 +41,12 @@
         <!-- Enter any references or sources using the format example below. 
              If this is an original code sample you can just delete the Source: line below
         -->
-        <p>Source:
-            <ul> 
-            <li><a href="https://www.w3.org/TR/WCAG20-TECHS/general.html#G85" target="_blank">WCAG G85: Providing a text description when user input falls 
+        <h3>Source:</h3>
+        <p>
+            <ul>
+                <li><a href="https://www.w3.org/TR/WCAG20-TECHS/general.html#G85" target="_blank">WCAG G85: Providing a text description when user input falls 
             outside the required format or values</a></li>
-            <li><a href="https://github.com/IBMa/Va11yS/blob/master/GENERAL/G85_example1.html" target="_blank">Source Code on GitHub</a></li>
+                <li><a href="https://github.com/IBMa/Va11yS/blob/master/WCAG_GENERAL/G85_example1.html" target="_blank">Source Code on GitHub</a></li>
             </ul>
         </p>
         <!-- Enter testing results following examples below.  Include:  OS, Browser, AT used, and result -->
@@ -52,7 +55,8 @@
             <ul>
                 <li>Windows 7, Firefox ESR 49.0.1, and JAWS 17
                     <ul>
-                        <li>Result: An alert dialog appears upon exiting the field or submiting the form if the data is not in the correct format.
+                        <li>Result: An alert dialog appears upon exiting the field or submiting the form if the data is not in
+                            the correct format.
                         </li>
                     </ul>
                 </li>
@@ -62,5 +66,3 @@
 </body>
 
 </html>
-
- 

--- a/WCAG_GENERAL/G85_example1.html
+++ b/WCAG_GENERAL/G85_example1.html
@@ -42,13 +42,13 @@
              If this is an original code sample you can just delete the Source: line below
         -->
         <h3>Source:</h3>
-        <p>
+        <div>
             <ul>
                 <li><a href="https://www.w3.org/TR/WCAG20-TECHS/general.html#G85" target="_blank">WCAG G85: Providing a text description when user input falls 
             outside the required format or values</a></li>
                 <li><a href="https://github.com/IBMa/Va11yS/blob/master/WCAG_GENERAL/G85_example1.html" target="_blank">Source Code on GitHub</a></li>
             </ul>
-        </p>
+        </div>
         <!-- Enter testing results following examples below.  Include:  OS, Browser, AT used, and result -->
         <h3>Tested on:</h3>
         <div>

--- a/WCAG_HTML/H2_example1.html
+++ b/WCAG_HTML/H2_example1.html
@@ -30,9 +30,14 @@
         <!-- Enter any references or sources using the format example below. 
              If this is an original code sample you can just delete the Source: line below
         -->
-        <p>Source: <a href="https://www.w3.org/TR/WCAG20-TECHS/H2.html" target="_blank">WCAG H2:  The icon and text are contained
-            in the same a element</a></p>
-            <p><a href="https://github.com/IBMa/Va11yS/blob/master/HTML/H2_example1.html" target="_blank">View code</a> on GitHub</p>
+        <h3>Source:</h3>
+        <div>
+            <ul>
+                <li><a href="https://www.w3.org/TR/WCAG20-TECHS/H2.html" target="_blank">WCAG H2:  The icon and text are contained
+            in the same a element</a></li>
+                <li><a href="https://github.com/IBMa/Va11yS/blob/master/WCAG_HTML/H2_example1.html" target="_blank">Source code on GitHub</a></li>
+            </ul>
+        </div>
         <!-- Enter testing results:  OS, Browser, AT used, and result -->
         <h3>Tested on:</h3>
         <div>
@@ -47,7 +52,7 @@
                         <li>Result: iOS VoiceOver announces product page link, end main.</li>
                     </ul>
                 </li>
-                <li>Android 7.1.1, Chrome browser, Talkback 5.2 
+                <li>Android 7.1.1, Chrome browser, Talkback 5.2
                     <ul>
                         <li>Result: Talkback announces products page link.</li>
                     </ul>

--- a/WCAG_HTML/H2_example1.html
+++ b/WCAG_HTML/H2_example1.html
@@ -17,7 +17,7 @@
         <hr>
     </header>
     <main role="main">
-        <h1>H2 Example 1: Icon and text in the same <code>a</code> element</a></h1>
+        <h1>H2 Example 1: Icon and text in the same <code>a</code> element</h1>
         <!-- Component start -->
         <a href="extras/products.html">
             <img src="img/icon.gif" alt=""> Products page

--- a/WCAG_HTML/H2_example1.html
+++ b/WCAG_HTML/H2_example1.html
@@ -30,8 +30,8 @@
         <!-- Enter any references or sources using the format example below. 
              If this is an original code sample you can just delete the Source: line below
         -->
-        <p>WCAG Source: <a href="https://www.w3.org/TR/WCAG20-TECHS/H2.html" target="_blank">WCAG H2</a>: The icon and text are contained
-            in the same a element.</p>
+        <p>Source: <a href="https://www.w3.org/TR/WCAG20-TECHS/H2.html" target="_blank">WCAG H2:  The icon and text are contained
+            in the same a element</a></p>
             <p><a href="https://github.com/IBMa/Va11yS/blob/master/HTML/H2_example1.html" target="_blank">View code</a> on GitHub</p>
         <!-- Enter testing results:  OS, Browser, AT used, and result -->
         <h3>Tested on:</h3>

--- a/WCAG_HTML/H42_example1.html
+++ b/WCAG_HTML/H42_example1.html
@@ -46,8 +46,11 @@
         <!-- Enter any references or sources using the format example below. 
              If this is an original code sample you can just delete the Source: line below
         -->
-        <p>WCAG Source: <a href="https://www.w3.org/TR/WCAG20-TECHS/H42.html" target="_blank">H42</a></p>
-        <p><a href="https://github.com/IBMa/Va11yS/blob/master/HTML/H42_example1.html" target="_blank">View code</a> on GitHub</p>
+        <h3>Source: </h3>
+        <ul>
+            <li><a href="https://www.w3.org/TR/WCAG20-TECHS/H42.html" target="_blank">WCAG H42: Using h1-h6 to identify headings</a></li>
+            <li><a href="https://github.com/IBMa/Va11yS/blob/master/WCAG_HTML/H42_example1.html" target="_blank">Source code on GitHub</a></li>
+        </ul>
         <!-- Enter testing results following examples below.  Include:  OS, Browser, AT used, and result -->
         <h3>Tested on:</h3>
         <div>

--- a/WCAG_HTML/H51_example1.html
+++ b/WCAG_HTML/H51_example1.html
@@ -12,7 +12,7 @@
     <!-- Header w/ breadcrumb (Adjust breadcrumb links as needed) -->
     <header role="banner">
         <nav role="navigation">
-            <a href="../index.html">Home</a> > <a href="html_techniques.html">WCAG HTML Techniques</a>
+            <a href="../index.html">Home</a> &gt; <a href="html_techniques.html">WCAG HTML Techniques</a>
         </nav>
         <hr>
     </header>
@@ -53,8 +53,9 @@
         <!-- Enter any references or sources using the format example below. 
              If this is an original code sample you can just delete the Source: line below
         -->
-        <p>Source: <a href="https://www.w3.org/TR/WCAG20-TECHS/H51.html" target="_blank">WCAG H51</a></p>
-        <p><a href="https://github.com/IBMa/Va11yS/blob/master/HTML/H51_example1.html" target="_blank">View code</a> on GitHub</p>
+        <h3>Source: </h3>
+        <li><a href="https://www.w3.org/TR/WCAG20-TECHS/H51.html" target="_blank">H51: Using table markup to present tabular information</a></li>
+        <li><a href="https://github.com/IBMa/Va11yS/blob/master/WCAG_HTML/H51_example1.html" target="_blank">Source code on GitHub</a></li>
         <!-- Enter testing results:  OS, Browser, AT used, and result -->
         <h3>Tested on:</h3>
         <div>


### PR DESCRIPTION
Updated Source section (h3 + bullets) - fixed GH source links - Updated H1 to match target - fixed WCAG link text in several examples

ARIA1_example1.html
ARIA1_example2.html
ARIA2_example1.html
G55_example1.html
G58_example1.html
G65_example1.html
G70_example1.html
G71_example1.html
G73_example1.html
G74_example1.html
G80_example1.html
G85_example1.html


H2_example1.html
H42_example1.html
H51_example1.html
