### PR TITLE
ARIA18 - Update CDN & change to https

### DIFF
--- a/WCAG_ARIA/ARIA18_example1.html
+++ b/WCAG_ARIA/ARIA18_example1.html
@@ -5,8 +5,8 @@
     <meta name="viewport" content="width=device-width, minimal-ui">
     <meta charset="utf-8">
     <link rel="stylesheet" type="text/css" href="css/style_ARIA18.css">
-	<title>ARIA18 - Example 1</title>
-	<script src="http://code.jquery.com/jquery.js"></script>
+    <title>ARIA18 - Example 1</title>
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>
 	<script>
 	$(document).ready(function(e) {
 		$('#trigger-alertdialog').click(function() {


### PR DESCRIPTION
Changed jQuery to Google's CDN and changed link from http to https to fix the error reported in Issue #184 